### PR TITLE
Fixes build config to use vitest

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,7 +14,8 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "allowJs": true
+    "allowJs": true,
+    "types": ["vitest/globals", "node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This PR fixes the `tsconfig.build.json` to introduce the types of vitest here.

Going to merge this soon.